### PR TITLE
Update cache action to v4

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       id: yarn-cache
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
The cache actions v1 and v2 are being deprecated, see more [here](https://github.com/actions/cache/discussions/1510).

This PR changes the version to the latest v4, there are no other changes required in the workflow to support the upgrade.